### PR TITLE
Search for WWDR across all keychains

### DIFF
--- a/bin/passkit-keys
+++ b/bin/passkit-keys
@@ -38,7 +38,6 @@ const res = execFileSync(
     '-p',
     '-c',
     'Apple Worldwide Developer Relations Certification Authority',
-    'login.keychain',
   ],
   { stdio: ['inherit', 'pipe', 'inherit'] },
 );


### PR DESCRIPTION
On my MacBook Pro (Mojave 10.14.6, Xcode 10.3) the `passkit-keys` program failed to find my Apple WWDR key. I found that this is because mine is in the System keychain rather than the Login keychain 🤷‍♂️. Removing the keychain to search (`login.keychain`) found it for me.

Something else I found is that if I *did* want to search a specific keychain it wasn't enough to put `System.keychain` or `login.keychain`, it had to be the full path to it (`/Library/Keychains/System.keychain`, for example). So I'd end up with a command looking like this:

```sh
security find-certificate -p -c "Apple Worldwide Developer Relations Certification Authority" /Library/Keychains/System.keychain
```

Hopefully the change in this PR should enable it to work for a lot more people.

I'm also confused about the line in the README:

> The Apple Worldwide Developer Relations Certification Authority certificate is not needed anymore since it is already included in this package.

If this is the case can we delete this code to find the WWDR altogether?
